### PR TITLE
fix: chisel version has changed from 0.8 to 0.8.0

### DIFF
--- a/python3.8/Dockerfile.20.04
+++ b/python3.8/Dockerfile.20.04
@@ -4,7 +4,7 @@ ARG USER=ubuntu UID=101 GROUP=ubuntu GID=101
 FROM ubuntu:$UBUNTU_RELEASE AS builder
 ARG USER UID GROUP GID TARGETARCH
 SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
-ADD https://github.com/canonical/chisel/releases/download/v0.8/chisel_v0.8_linux_${TARGETARCH}.tar.gz chisel.tar.gz
+ADD https://github.com/canonical/chisel/releases/download/v0.8.0/chisel_v0.8.0_linux_${TARGETARCH}.tar.gz chisel.tar.gz
 RUN tar -xvf chisel.tar.gz -C /usr/bin/
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates \


### PR DESCRIPTION
Due to https://github.com/canonical/chisel/issues/96, chisel version 0.8 has been renamed to 0.8.0. This commit updates the new version in the Dockerfiles.
