### PR TITLE
Use Renovate to auto-upgrade Chisel version

### DIFF
--- a/python3.8/Dockerfile.20.04
+++ b/python3.8/Dockerfile.20.04
@@ -1,10 +1,11 @@
 ARG UBUNTU_RELEASE=20.04
 ARG USER=ubuntu UID=101 GROUP=ubuntu GID=101
+ARG CHISEL_VERSION=0.8.0
 
 FROM ubuntu:$UBUNTU_RELEASE AS builder
-ARG USER UID GROUP GID TARGETARCH
+ARG USER UID GROUP GID TARGETARCH CHISEL_VERSION
 SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
-ADD https://github.com/canonical/chisel/releases/download/v0.8.0/chisel_v0.8.0_linux_${TARGETARCH}.tar.gz chisel.tar.gz
+ADD https://github.com/canonical/chisel/releases/download/v${CHISEL_VERSION}/chisel_v${CHISEL_VERSION}_linux_${TARGETARCH}.tar.gz chisel.tar.gz
 RUN tar -xvf chisel.tar.gz -C /usr/bin/
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates \

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,18 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "(^|/|\\.)([Dd]ocker|[Cc]ontainer)file$",
+        "(^|/)([Dd]ocker|[Cc]ontainer)file[^/]*$"
+      ],
+      "matchStrings": ["ARG CHISEL_VERSION=(?<currentValue>.*?)\\s"],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "canonical/chisel",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    }
   ]
 }


### PR DESCRIPTION
This PR adds two commits for a single purpose -- making renovate track chisel updates and adding a PR whenever a new version is available. Renovate reference: https://docs.renovatebot.com/modules/manager/regex/.

A demo can be found in my repo: https://github.com/rebornplusplus/chiselled-python/issues/3

_(ROCKS-932)_