### PR TITLE
feat: create python3.12 rock

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,12 +9,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ["3.8", "3.11"]
+        version: ["3.8", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build python${{ matrix.version}} rock
+      - name: Build python${{ matrix.version }} rock
         id: build
         uses: canonical/craft-actions/rockcraft-pack@main
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .vscode
+*.rock
+

--- a/python3.11/README.md
+++ b/python3.11/README.md
@@ -23,14 +23,14 @@ Import the recently created rock into Docker using
 ```sh
 $ /snap/rockcraft/current/bin/skopeo copy \
 	oci-archive:python_3.11_amd64.rock \
-	docker-daemon:ubuntu/chiselled-python:3.11
+	docker-daemon:ubuntu/python:3.11
 ```
 
 The image has `pebble enter --verbose` as entrypoint. [Learn about
 pebble](https://github.com/canonical/pebble).
 
 ```sh
-$ docker run ubuntu/chiselled-python:3.11
+$ docker run ubuntu/python:3.11
 2024-02-22T09:16:53.017Z [pebble] Started daemon.
 2024-02-22T09:16:53.020Z [pebble] POST /v1/services 284.402µs 400
 2024-02-22T09:16:53.020Z [pebble] Cannot start default services: no default services
@@ -60,7 +60,7 @@ print("hello world")
 You may create the following Dockerfile for your application image:
 
 ```Dockerfile
-FROM ubuntu/chiselled-python:3.11
+FROM ubuntu/python:3.11
 
 ADD main.py /
 
@@ -86,7 +86,7 @@ Let's assume the previous hello world example file at `./app/main.py`. You may r
 the application with the Chiselled Python image as shown below:
 
 ```sh
-$ docker run -v ./app:/app ubuntu/chiselled-python:3.11 \
+$ docker run -v ./app:/app ubuntu/python:3.11 \
 	exec python3 /app/main.py 2> logs
 hello world
 ```

--- a/python3.12/README.md
+++ b/python3.12/README.md
@@ -1,0 +1,84 @@
+# Chiselled Python3.12
+
+This directory contains the image recipes of Chiselled Python3.12. These
+images are smaller in size, hence less prone to vulnerabilities. Know
+more about chisel [here](https://github.com/canonical/chisel).
+
+We currently have Chiselled Python3.12 on Noble. See
+[rockcraft.yaml](./rockcraft.yaml).
+
+### Building the image(s)
+
+Build the rock in the usual way:
+
+```sh
+rockcraft pack
+```
+
+### Running the image(s)
+
+Import the recently created rock into Docker using
+[skopeo](https://github.com/containers/skopeo).
+
+```sh
+$ /snap/rockcraft/current/bin/skopeo copy \
+ oci-archive:python_3.12_amd64.rock \
+ docker-daemon:ubuntu/python:3.12
+```
+
+The image has `pebble enter --verbose` as entrypoint. [Learn about
+Pebble](https://github.com/canonical/pebble).
+
+You can access the `python3` interpreter with the following command:
+
+```sh
+$ docker run --rm -it ubuntu/python:3.12 exec python3
+Python 3.12.3 (main, Apr 10 2024, 05:33:47) [GCC 13.2.0] on linux
+Type "help", "copyright", "credits" or "license" for more information.
+>>> print("hello world")
+hello world
+>>> exit()
+```
+
+### Building and running an application on Chiselled Python3.12
+
+Let's assume, you have the following Python3 source code you want to run
+as an application. Assume the file is called `main.py`.
+
+```py
+print("hello world")
+```
+
+You may create the following Dockerfile for your application image:
+
+```Dockerfile
+FROM ubuntu/python:3.12
+
+ADD main.py /
+
+ENTRYPOINT ["python3", "/main.py"]
+```
+
+Build the image:
+
+```sh
+docker build -t myapp -f Dockerfile.app .
+```
+
+Run your application container:
+
+```sh
+$ docker run myapp
+hello world
+```
+
+### Running a simple Python script without building another image
+
+Let's assume the previous hello world example file at `./app/main.py`. You may run
+the application with the Chiselled Python image as shown below:
+
+```sh
+$ docker run -v ./app:/app ubuntu/python:3.12 \
+ exec python3 /app/main.py 2> logs
+hello world
+```

--- a/python3.12/rockcraft.yaml
+++ b/python3.12/rockcraft.yaml
@@ -1,0 +1,34 @@
+name: python
+version: "3.12"
+summary: Chiselled Python 3.12 rock
+description: |
+  Python is a high-level, general-purpose programming language. Its design
+  philosophy emphasizes code readability with the use of significant
+  indentation. Python is dynamically typed and garbage-collected. It supports
+  multiple programming paradigms, including structured, object-oriented and
+  functional programming.  Read more on [python.org](https://www.python.org/).
+
+  This image is a chiselled Ubuntu rock that contains only the Python runtime
+  and its standard libraries.
+license: Python-2.0
+base: bare
+build-base: ubuntu@24.04
+
+run-user: _daemon_
+
+platforms:
+  amd64:
+
+parts:
+  python3:
+    plugin: nil
+    stage-packages:
+      - base-files_base
+      - ca-certificates_data
+      - libc6_libs
+      - libgcc-s1_libs
+      - openssl_config
+      - python3.12_standard
+    override-prime: |
+      craftctl default
+      ln -s /usr/bin/python3.12 $CRAFT_PRIME/usr/bin/python3

--- a/python3.8/README.md
+++ b/python3.8/README.md
@@ -21,14 +21,14 @@ Import the recently created rock into Docker using
 [skopeo](https://github.com/containers/skopeo).
 
 ```sh
-$ skopeo copy oci-archive:python_3.8_amd64.rock docker-daemon:ubuntu/chiselled-python:3.8
+$ skopeo copy oci-archive:python_3.8_amd64.rock docker-daemon:ubuntu/python:3.8
 ```
 
 The image has `pebble enter --verbose` as entrypoint. [Learn about
 pebble](https://github.com/canonical/pebble).
 
 ```sh
-$ docker run -it ubuntu/chiselled-python:3.8
+$ docker run -it ubuntu/python:3.8
 2024-01-25T10:20:35.681Z [pebble] Started daemon.
 2024-01-25T10:20:35.687Z [pebble] POST /v1/services 1.941757ms 400
 2024-01-25T10:20:35.687Z [pebble] Cannot start default services: no default services
@@ -59,7 +59,7 @@ print("hello world")
 You may create the following Dockerfile for your application image:
 
 ```Dockerfile
-FROM ubuntu/chiselled-python:3.8
+FROM ubuntu/python:3.8
 
 ADD main.py /
 
@@ -85,7 +85,7 @@ You can run your python application as a pebble service too. There is a
 `python3` service inside the rock that you can utilise.
 
 ```sh
-$ docker run -it -v $PWD:/app:ro ubuntu/chiselled-python:3.8 \
+$ docker run -it -v $PWD:/app:ro ubuntu/python:3.8 \
 	--args python3 /app/main.py \; start python3
 2024-01-25T10:30:16.708Z [pebble] Started daemon.
 2024-01-25T10:30:16.717Z [pebble] POST /v1/services 6.882444ms 202


### PR DESCRIPTION
Adding the chiselled rock recipe and README for python 3.12 on 24.04

TODO:
 - create the PR for the OCI Factory
 - bump the 3.8 rock to stable