### PR TITLE
feat: add python3.13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ["3.8", "3.10", "3.11", "3.12"]
+        version: ["3.8", "3.10", "3.11", "3.12", "3.13"]
         runner: ["X64", "ARM64"]
 
     steps:

--- a/python3.13/rockcraft.yaml
+++ b/python3.13/rockcraft.yaml
@@ -35,3 +35,6 @@ parts:
           libgcc-s1_libs \
           openssl_config \
           python3.13_standard
+    override-prime: |
+      craftctl default
+      ln -s /usr/bin/python3.13 $CRAFT_PRIME/usr/bin/python3

--- a/python3.13/rockcraft.yaml
+++ b/python3.13/rockcraft.yaml
@@ -1,0 +1,36 @@
+name: python
+version: "3.13"
+summary: Chiseled Python 3.13 rock
+description: |
+  Python is a high-level, general-purpose programming language. Its design
+  philosophy emphasizes code readability with the use of significant
+  indentation. Python is dynamically typed and garbage-collected. It supports
+  multiple programming paradigms, including structured, object-oriented and
+  functional programming.  Read more on [python.org](https://www.python.org/).
+
+  This image is a chiselled Ubuntu rock that contains only the Python runtime
+  and its standard libraries.
+license: Python-2.0
+base: bare
+build-base: ubuntu@24.04
+
+run-user: _daemon_
+
+platforms:
+  amd64:
+  arm64:
+
+parts:
+  python3:
+    plugin: nil
+    override-build: |
+      chisel cut --release ubuntu-25.04 \
+          --root $CRAFT_PART_INSTALL \
+          base-files_base \
+          base-files_release-info \
+          base-files_chisel \
+          ca-certificates_data \
+          libc6_libs \
+          libgcc-s1_libs \
+          openssl_config \
+          python3.13_standard

--- a/python3.13/rockcraft.yaml
+++ b/python3.13/rockcraft.yaml
@@ -12,6 +12,7 @@ description: |
   and its standard libraries.
 license: Python-2.0
 base: bare
+# TODO: Update to 25.04 when available
 build-base: ubuntu@24.04
 
 run-user: _daemon_

--- a/python3.13/rockcraft.yaml
+++ b/python3.13/rockcraft.yaml
@@ -34,7 +34,4 @@ parts:
           libc6_libs \
           libgcc-s1_libs \
           openssl_config \
-          python3.13_standard
-    override-prime: |
-      craftctl default
-      ln -s /usr/bin/python3.13 $CRAFT_PRIME/usr/bin/python3
+          python3_standard


### PR DESCRIPTION
Creates python3.13 on Plucky, using a script to bypass the lack of interim bases support in Rockcraft.