### PR TITLE
feat: add base-files_release-info to all rocks

### DIFF
--- a/python3.10/rockcraft.yaml
+++ b/python3.10/rockcraft.yaml
@@ -25,6 +25,7 @@ parts:
     plugin: nil
     stage-packages:
       - base-files_base
+      - base-files_release-info
       - base-files_chisel
       - ca-certificates_data
       - libc6_libs

--- a/python3.11/rockcraft.yaml
+++ b/python3.11/rockcraft.yaml
@@ -25,6 +25,7 @@ parts:
     plugin: nil
     stage-packages:
       - base-files_base
+      - base-files_release-info
       - base-files_chisel
       - ca-certificates_data
       - libc6_libs

--- a/python3.12/rockcraft.yaml
+++ b/python3.12/rockcraft.yaml
@@ -25,6 +25,7 @@ parts:
     plugin: nil
     stage-packages:
       - base-files_base
+      - base-files_release-info
       - base-files_chisel
       - ca-certificates_data
       - libc6_libs


### PR DESCRIPTION
This add the base-files_release-info slice to every image, making it easy for 3rd party tools to infer the distro.

---
@zhijie-yang please release the relevant rocks after the merge.